### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+      - run: pip install -r requirements.txt
+      - name: Byte-compile sources
+        run: python -m py_compile app.py castle_config.py demo_config.py
+      - name: Import smoke test
+        run: python -c "import app; print('app imported OK')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  smoke:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,8 +15,8 @@ jobs:
         with:
           python-version: '3.13'
           cache: pip
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements-dev.txt
       - name: Byte-compile sources
         run: python -m py_compile app.py castle_config.py demo_config.py
-      - name: Import smoke test
-        run: python -c "import app; print('app imported OK')"
+      - name: Run tests
+        run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = -ra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8,<9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-pytest>=8,<9
+pytest>=9,<10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+"""Shared pytest fixtures for the Castle demo app.
+
+The Castle SDK is always mocked in these tests so the suite never makes a real
+network call. We set deterministic env defaults *before* importing ``app`` so
+that ``castle_config`` and the route handlers see stable values regardless of
+the developer's local ``.env``.
+"""
+import os
+
+import pytest
+
+# Deterministic env, applied before `app` is imported below.
+TEST_ENV = {
+    "castle_api_secret": "test_secret",
+    "castle_pk": "pk_test",
+    "location": "test",
+    "valid_username": "clark.kent@dailyplanet.com",
+    "valid_password": "supersecret",
+    "valid_user_id": "00000000",
+    "invalid_password": "qwerty",
+    "webhook_url": "https://webhook.site",
+}
+for key, value in TEST_ENV.items():
+    os.environ[key] = value
+
+import app as app_module  # noqa: E402  (must follow the env setup above)
+
+# The known-good registration date the app uses as a module-level default. The
+# `evaluate_login` handler mutates this global, so we restore it before each test.
+DEFAULT_REGISTERED_AT = "2020-02-23T22:28:55.387Z"
+
+
+@pytest.fixture
+def app():
+    app_module.app.config.update(TESTING=True)
+    return app_module.app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def reset_module_state():
+    """Reset the mutable module-level state the handlers touch."""
+    app_module.registered_at = DEFAULT_REGISTERED_AT
+    yield
+    app_module.registered_at = DEFAULT_REGISTERED_AT

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,0 +1,34 @@
+"""Smoke tests for the rendered demo pages."""
+import pytest
+
+from demo_config import valid_urls
+
+
+def test_home_renders(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"<html" in resp.data.lower()
+
+
+@pytest.mark.parametrize("demo_name", valid_urls)
+def test_every_demo_page_renders(client, demo_name):
+    resp = client.get(f"/{demo_name}")
+    assert resp.status_code == 200
+    assert b"<html" in resp.data.lower()
+
+
+def test_demo_list_matches_config():
+    # Guards against the demo list and the URL allowlist drifting apart.
+    assert set(valid_urls) == {"login", "password_reset", "lists", "privacy", "events"}
+
+
+def test_unknown_demo_renders_error_page(client):
+    resp = client.get("/does-not-exist")
+    assert resp.status_code == 200
+    # error.html is served instead of a demo template.
+    assert b"<html" in resp.data.lower()
+
+
+def test_unknown_vendor_asset_returns_404(client):
+    resp = client.get("/vendor/castle-js/nope.js")
+    assert resp.status_code == 404

--- a/tests/test_sdk_integration.py
+++ b/tests/test_sdk_integration.py
@@ -1,0 +1,281 @@
+"""Tests for how the app integrates with the Castle SDK.
+
+The SDK ``Client`` is mocked everywhere, so these assert *how* the app calls the
+SDK (which endpoint, with what payload) and how it handles ``CastleError`` —
+not the SDK's own behavior or any live API.
+
+Two seams are patched:
+- ``app.Client`` for the request-scoped flows (login / password reset), which
+  build the client via ``Client.from_request(request)``.
+- ``app.castle_client`` for the account-level flows (lists / privacy / events).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from castle.errors import CastleError
+
+import app as app_module
+
+
+def _post(client, path, payload):
+    return client.post(path, json=payload)
+
+
+@pytest.fixture
+def fake_sdk():
+    """A mock Castle client wired into both client-creation seams."""
+    fake = MagicMock(name="castle_client")
+    with patch.object(app_module, "Client") as mock_client_cls, \
+            patch.object(app_module, "castle_client", return_value=fake):
+        mock_client_cls.from_request.return_value = fake
+        yield fake
+
+
+# ---------------------------------------------------------------------------
+# Risk / filter (login)
+# ---------------------------------------------------------------------------
+class TestEvaluateLogin:
+    def test_valid_credentials_call_risk(self, client, fake_sdk):
+        fake_sdk.risk.return_value = {"policy": {"action": "allow"}}
+
+        resp = _post(client, "/evaluate_login", {
+            "email": "clark.kent@dailyplanet.com",
+            "password": "supersecret",
+            "request_token": "tok-123",
+        })
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["api_endpoint"] == "risk"
+        assert body["castle_type"] == "$login"
+        assert body["castle_status"] == "$succeeded"
+        assert body["result"] == {"policy": {"action": "allow"}}
+
+        fake_sdk.risk.assert_called_once()
+        fake_sdk.filter.assert_not_called()
+        sent = fake_sdk.risk.call_args.args[0]
+        assert sent["type"] == "$login"
+        assert sent["status"] == "$succeeded"
+        assert sent["user"]["id"] == "00000000"
+        assert sent["user"]["email"] == "clark.kent@dailyplanet.com"
+        assert sent["user"]["registered_at"]
+        assert sent["request_token"] == "tok-123"
+
+    def test_valid_user_wrong_password_calls_filter(self, client, fake_sdk):
+        fake_sdk.filter.return_value = {"policy": {"action": "deny"}}
+
+        resp = _post(client, "/evaluate_login", {
+            "email": "clark.kent@dailyplanet.com",
+            "password": "wrong-password",
+            "request_token": "tok-456",
+        })
+
+        body = resp.get_json()
+        assert body["api_endpoint"] == "filter"
+        assert body["castle_status"] == "$failed"
+
+        fake_sdk.filter.assert_called_once()
+        fake_sdk.risk.assert_not_called()
+        sent = fake_sdk.filter.call_args.args[0]
+        # A known user keeps their id and registered_at.
+        assert sent["user"]["id"] == "00000000"
+        assert "registered_at" in sent["user"]
+
+    def test_unknown_user_calls_filter_without_user_id(self, client, fake_sdk):
+        fake_sdk.filter.return_value = {"policy": {"action": "deny"}}
+
+        resp = _post(client, "/evaluate_login", {
+            "email": "stranger@example.com",
+            "password": "whatever",
+            "request_token": "tok-789",
+        })
+
+        body = resp.get_json()
+        assert body["api_endpoint"] == "filter"
+        sent = fake_sdk.filter.call_args.args[0]
+        assert sent["user"]["id"] is None
+        # registered_at is dropped for an unknown user.
+        assert "registered_at" not in sent["user"]
+
+
+# ---------------------------------------------------------------------------
+# Log (password reset)
+# ---------------------------------------------------------------------------
+class TestEvaluateNewPassword:
+    def test_new_password_logs_succeeded(self, client, fake_sdk):
+        resp = _post(client, "/evaluate_new_password", {
+            "password": "a-brand-new-password",
+            "request_token": "tok-1",
+        })
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["api_endpoint"] == "log"
+        assert body["status"] == "$succeeded"
+
+        fake_sdk.log.assert_called_once()
+        sent = fake_sdk.log.call_args.args[0]
+        assert sent["type"] == "$password_reset"
+        assert sent["status"] == "$succeeded"
+        assert sent["user"]["email"] == "clark.kent@dailyplanet.com"
+
+    def test_reusing_current_password_logs_failed(self, client, fake_sdk):
+        resp = _post(client, "/evaluate_new_password", {
+            "password": "supersecret",
+            "request_token": "tok-2",
+        })
+
+        body = resp.get_json()
+        assert body["status"] == "$failed"
+        fake_sdk.log.assert_called_once()
+        assert fake_sdk.log.call_args.args[0]["status"] == "$failed"
+
+
+# ---------------------------------------------------------------------------
+# Lists API
+# ---------------------------------------------------------------------------
+class TestCreateList:
+    def test_defaults_create_then_fetch(self, client, fake_sdk):
+        fake_sdk.create_list.return_value = {"id": "list-1"}
+        fake_sdk.get_all_lists.return_value = [{"id": "list-1"}]
+
+        resp = _post(client, "/create_list", {})
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["api_endpoint"] == "lists"
+        assert body["payload_to_castle"] == {
+            "name": "demo-blocklist",
+            "color": "$red",
+            "primary_field": "user.email",
+        }
+        assert body["result"]["created"] == {"id": "list-1"}
+        assert body["result"]["all_lists"] == [{"id": "list-1"}]
+        fake_sdk.create_list.assert_called_once()
+        fake_sdk.get_all_lists.assert_called_once()
+
+    def test_custom_payload_is_forwarded(self, client, fake_sdk):
+        fake_sdk.create_list.return_value = {"id": "list-2"}
+        fake_sdk.get_all_lists.return_value = []
+
+        resp = _post(client, "/create_list", {
+            "name": "vip",
+            "color": "$green",
+            "primary_field": "user.id",
+        })
+
+        sent = fake_sdk.create_list.call_args.args[0]
+        assert sent == {"name": "vip", "color": "$green", "primary_field": "user.id"}
+        assert resp.get_json()["payload_to_castle"] == sent
+
+    def test_castle_error_is_handled(self, client, fake_sdk):
+        fake_sdk.create_list.side_effect = CastleError("list blew up")
+
+        resp = _post(client, "/create_list", {})
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["result"] == {"error": "list blew up"}
+        fake_sdk.get_all_lists.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Privacy API
+# ---------------------------------------------------------------------------
+class TestPrivacyUserData:
+    def test_default_action_requests_data(self, client, fake_sdk):
+        fake_sdk.request_user_data.return_value = {"status": "ok"}
+
+        resp = _post(client, "/privacy_user_data", {})
+
+        body = resp.get_json()
+        assert body["api_endpoint"] == "privacy (request)"
+        assert body["payload_to_castle"] == {
+            "identifier": "clark.kent@dailyplanet.com",
+            "identifier_type": "$email",
+        }
+        fake_sdk.request_user_data.assert_called_once()
+        fake_sdk.delete_user_data.assert_not_called()
+
+    def test_delete_action_deletes_data(self, client, fake_sdk):
+        fake_sdk.delete_user_data.return_value = {"status": "deleted"}
+
+        resp = _post(client, "/privacy_user_data", {
+            "action": "delete",
+            "identifier": "someone@else.com",
+            "identifier_type": "$user_id",
+        })
+
+        body = resp.get_json()
+        assert body["api_endpoint"] == "privacy (delete)"
+        assert body["payload_to_castle"] == {
+            "identifier": "someone@else.com",
+            "identifier_type": "$user_id",
+        }
+        fake_sdk.delete_user_data.assert_called_once()
+        fake_sdk.request_user_data.assert_not_called()
+
+    def test_castle_error_is_handled(self, client, fake_sdk):
+        fake_sdk.request_user_data.side_effect = CastleError("privacy failure")
+
+        resp = _post(client, "/privacy_user_data", {})
+
+        body = resp.get_json()
+        assert body["api_endpoint"] == "privacy"
+        assert body["result"] == {"error": "privacy failure"}
+
+
+# ---------------------------------------------------------------------------
+# Events API
+# ---------------------------------------------------------------------------
+class TestEvents:
+    def test_events_schema_success(self, client, fake_sdk):
+        fake_sdk.events_schema.return_value = {"fields": ["name"]}
+
+        resp = _post(client, "/events_schema", {})
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["api_endpoint"] == "events/schema"
+        assert body["result"] == {"fields": ["name"]}
+        fake_sdk.events_schema.assert_called_once()
+
+    def test_events_schema_handles_castle_error(self, client, fake_sdk):
+        fake_sdk.events_schema.side_effect = CastleError("schema down")
+
+        resp = _post(client, "/events_schema", {})
+
+        assert resp.get_json()["result"] == {"error": "schema down"}
+
+    def test_query_events_default_filter(self, client, fake_sdk):
+        fake_sdk.query_events.return_value = {"events": []}
+
+        resp = _post(client, "/query_events", {})
+
+        body = resp.get_json()
+        assert body["api_endpoint"] == "events/query"
+        sent = fake_sdk.query_events.call_args.args[0]
+        assert sent["filters"] == [{"field": "name", "op": "$eq", "value": "$login"}]
+        assert sent["sort"] == {"field": "created_at", "order": "desc"}
+
+    def test_query_events_custom_filter(self, client, fake_sdk):
+        fake_sdk.query_events.return_value = {"events": []}
+
+        resp = _post(client, "/query_events", {
+            "field": "user.id",
+            "op": "$neq",
+            "value": "00000000",
+        })
+
+        sent = fake_sdk.query_events.call_args.args[0]
+        assert sent["filters"] == [
+            {"field": "user.id", "op": "$neq", "value": "00000000"}
+        ]
+
+    def test_query_events_handles_castle_error(self, client, fake_sdk):
+        fake_sdk.query_events.side_effect = CastleError("query down")
+
+        resp = _post(client, "/query_events", {})
+
+        assert resp.get_json()["result"] == {"error": "query down"}


### PR DESCRIPTION
## What & why

There was no CI for this example, so dependency or import regressions could land unnoticed. This adds a small GitHub Actions workflow that exercises the app on every push to `main` and on pull requests.

## What it does

On Python 3.13 it:

- installs the dependencies from `requirements.txt`,
- byte-compiles `app.py`, `castle_config.py` and `demo_config.py`, and
- runs an import smoke test (`python -c "import app"`) to confirm the app and the Castle SDK load.

## Known limitations

- This is a smoke check rather than a behavioral test suite — the app currently has no unit tests. It still catches the most common breakages (bad imports, dependency resolution, syntax errors).