### PR TITLE
Test against castle 7.2.0 from the tagged release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Flask>=3.1.3,<4
 gunicorn>=26.0
-castle>=7.1.0,<8
+# Test against the tagged 7.2.0 release before it lands on PyPI.
+# Once published, switch back to the registry version: castle>=7.2.0,<8
+castle @ git+https://github.com/castle/castle-python.git@v7.2.0
 python-dotenv>=1.2


### PR DESCRIPTION
Runs the demo against the new Castle Python SDK release ahead of its PyPI publish.

- Install `castle` from the `v7.2.0` Git tag.
- Keep a commented registry constraint (`castle>=7.2.0,<8`) to switch back to once the package is published.