### PR TITLE
Bump checkout and setup-python actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
           cache: pip


### PR DESCRIPTION
Update `actions/checkout` to v5 and `actions/setup-python` to v6 so the workflow actions run on the Node 24 runtime ahead of GitHub's deprecation of the Node 20 action runtime.