### PR TITLE
Proposal: modernize the CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
           cache: pip
       - run: pip install -r requirements-dev.txt
       - name: Byte-compile sources


### PR DESCRIPTION
> Draft proposal — opened for discussion, not yet ready to merge.

Runs the CI `test` job across a Python version matrix of `3.11`, `3.12` and `3.13` (with `fail-fast: false`) instead of a single fixed `3.13` interpreter. The setup-python step now selects the interpreter from `matrix.python-version`. All existing steps (checkout, dependency install, byte-compile, pytest) are unchanged.